### PR TITLE
added sendto script

### DIFF
--- a/sendto
+++ b/sendto
@@ -1,0 +1,62 @@
+#! /usr/bin/python3
+import subprocess
+import sys
+from os.path import exists
+GET_MAINTAINER_PATH = "./scripts/get_maintainer.pl"
+if not exists(GET_MAINTAINER_PATH):
+    raise Exception(f"Can't find {GET_MAINTAINER_PATH}, "
+    "are you in linux directory?"
+    )
+
+argv = sys.argv
+if len(argv) < 2:
+    raise Exception("Usage: $ sendto <patch_file>")
+if argv[1][-6:] != '.patch':
+    raise Exception("Need .patch file (check arg)")
+cmd = [f"{GET_MAINTAINER_PATH}", argv[1]]
+try:
+    result = subprocess.run(cmd, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+except:
+    print(f"subprocess.run failure... "
+    "Potentially lacking permissions for {GET_MAINTAINER_PATH}"
+    )
+
+get_maintainer_output = result.stdout.decode('UTF-8')
+get_maintainer_errors = result.stderr.decode('UTF-8')
+if len(get_maintainer_errors):
+    raise Exception(f"error in {GET_MAINTAINER_PATH}, check patch file")
+
+lines = []
+for line in get_maintainer_output.split('\n')[:-1]:
+    line = line.strip()
+    idx_of_paren = line.index('(')
+    before = line[0:idx_of_paren-1]
+    before = before.replace('"', '')
+    after = line[idx_of_paren+1:-1] 
+    lines.append((before, after))
+
+TO = '--to '
+CC = '--cc '
+send_info = []
+for (before, after) in lines:
+    is_maintainer = ('maintainer' in after)
+    res = (TO if is_maintainer else CC) + f'"{before}"'
+    send_info.append(res)
+
+warns = []
+clean = " \\\n".join(send_info)
+if '--to' not in clean and '--cc' not in clean:
+    warns.append(f"No recipients, manually check {GET_MAINTAINER_PATH}")
+elif '--to' not in clean:
+    warns.append(f"Lack of --to, manually check {GET_MAINTAINER_PATH}")
+
+output = \
+f'''
+git send-email \\
+{clean} {argv[1]}
+
+{''.join(f'# Warning: {warn}' for warn in warns)}
+{get_maintainer_errors}
+'''
+print(output, end='')


### PR DESCRIPTION
Use Case:
* Helps streamline the `get_maintainer` -> `git send-email` workflow by auto-running `./scripts/get_maintainer.pl`  and formatting the output to stdout. This output has, hopefully, intelligently chosen the appropriate `--to` and `--cc` flag for each recipient based on their maintainer status (also includes mailing lists).

Installation:
```
put in /usr/bin/sendto
```

Usage:
```
$ sendto <patch_file>
```
Example Output:
```
git send-email \
--to "Petr Mladek <pmladek@suse.com>" \
--to "Steven Rostedt <rostedt@goodmis.org>" \
--to "Sergey Senozhatsky <senozhatsky@chromium.org>" \
--cc "Andy Shevchenko <andriy.shevchenko@linux.intel.com>" \
--cc "Rasmus Villemoes <linux@rasmusvillemoes.dk>" \
--cc "Nathan Chancellor <nathan@kernel.org>" \
--cc "Nick Desaulniers <ndesaulniers@google.com>" \
--cc "Tom Rix <trix@redhat.com>" \
--cc "linux-kernel@vger.kernel.org" \
--cc "llvm@lists.linux.dev" v2-0002-lib-test_printf.c-fix-clang-Wformat-warnings.patch
```

Signed-off-by: Justin Stitt <justinstitt@google.com>