### PR TITLE
(GH Workflow) Dont run Lint Checks on .py files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,12 @@
-# Run shellcheck and shfmt
-name: Lint checks
-on: [push, pull_request]
+# Run shellcheck and shfmt                                                                                                                                                                                                                                    ▎     ▎
+name: Lint Checks
+on:
+  push:
+    paths-ignore:
+      - '**.py'
+  pull_request:
+    paths-ignore:
+      - '**.py'
 jobs:
   shellcheck:
     uses: ClangBuiltLinux/actions-workflows/.github/workflows/shellcheck.yml@main


### PR DESCRIPTION
## (GH Workflow) Dont run Lint Checks on .py files (errrr, at least don't run `ShellCheck` and `shfmt`)

#2 is failing because it's (majority) written in Python.

> Note: I didn't test this because I am not sure how to test it as non-contributor

see here:

```
Run bewuethr/shellcheck-action@v2
Run echo "Installing ShellCheck..." >&[2](https://github.com/ClangBuiltLinux/misc-scripts/actions/runs/5627571045/job/15250283989?pr=2#step:3:3)
Installing ShellCheck...
ShellCheck - shell script analysis tool
version: 0.8.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net
Run "$GITHUB_ACTION_PATH/runshellcheck"

In ./reduce/reduce.py line [16](https://github.com/ClangBuiltLinux/misc-scripts/actions/runs/5627571045/job/15250283989?pr=2#step:3:18):
VERSION = "0.2.1" # <--- perfectly legal (and well-formatted) python
        ^-- SC2283 (error): Remove spaces around = to assign (or use [ ] to compare, or quote '=' if literal).


In ./reduce/reduce.py line 18:
ENTRY_POINTS: dict[str, Callable] = {"prep": prep.main, "flags": flags.main}
                                    ^-- SC1083 (warning): This { is literal. Check expression (missing ;/\n?) or quote it.
                                                                           ^-- SC1083 (warning): This } is literal. Check expression (missing ;/\n?) or quote it.


In ./reduce/reduce.py line 21:
def parse_cli_args() -> argparse.Namespace:
                  ^-- SC1036 (error): '(' is invalid here. Did you forget to escape it?
                  ^-- SC1088 (error): Parsing stopped here. Invalid use of parentheses?

For more information:
  https://www.shellcheck.net//wiki/SC[22](https://github.com/ClangBuiltLinux/misc-scripts/actions/runs/5627571045/job/15250283989?pr=2#step:3:25)83 -- Remove spaces around = to assign ...
  https://www.shellcheck.net/wiki/SC1083 -- This { is literal. Check expressi...
  https://www.shellcheck.net/wiki/SC10[36](https://github.com/ClangBuiltLinux/misc-scripts/actions/runs/5627571045/job/15250283989?pr=2#step:3:39) -- '(' is invalid here. Did you forg...
Error: Process completed with exit code 1.
```